### PR TITLE
[Debug] Publish to npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,25 @@
+version: 2.1
+
+jobs:
+  deploy:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/node:12.18.3
+    steps:
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$npm_TOKEN" > ~/repo/.npmrc
+      - run:
+          name: Publish package
+          command: npm publish
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - deploy:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/package.json
+++ b/package.json
@@ -2,9 +2,8 @@
   "name": "@capmo/config",
   "version": "1.0.0",
   "publishConfig": {
-    "registry":"https://npm.pkg.github.com"
+    "registry": "https://npm.pkg.github.com"
   },
-  "repository": "https://github.com/capmo/config",
   "description": "Basic, extendable configuration for Product and Engineering team",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Publishing to npm as an open package has more sense comparing to private registry while it allows to skip authentication for all CIs which are using that package

⚠️This is for debug purpose ⚠️